### PR TITLE
BeseAreaクラスの作成

### DIFF
--- a/BaseArea.pde
+++ b/BaseArea.pde
@@ -1,0 +1,17 @@
+class BaseArea extends AbstractArea {
+
+  BaseArea(int posX, int posY, int yoko, int tate) {
+    super(posX, posY, yoko, tate);
+  }
+
+  void draw() {
+    for (int i=posX; i< posX+yoko; i++) {
+      for (int j=posY; j< posY+tate; j++) {
+        fill(#ffffc5);
+        if (i==posX) fill(#c5ffc5);
+        else if (i==posX+yoko-1) fill(#c5ffff);
+        rect(i*SQUARESIZE, j*SQUARESIZE, SQUARESIZE, SQUARESIZE);
+      }
+    }
+  }
+}


### PR DESCRIPTION
AbstractAreaクラスを継承する．
親クラス（AbstractAreaクラス）で定義されたエリアの左上座標(poX, posY)と縦幅(tate)，横幅(yoko)を親クラスのコンストラクタ(super(int posX, int posY, int yoko, int tate))を利用して初期化する．