### PR TITLE
HiyokoクラスにcanMove()メソッドを追加 

### DIFF
--- a/Hiyoko.pde
+++ b/Hiyoko.pde
@@ -3,4 +3,14 @@ class Hiyoko extends AbstractKoma {
   Hiyoko(String name, int x, int y, int team, boolean active) {
     super(name, x, y, team, active);
   }
+    boolean canMove(int toX, int toY) {
+
+    if (!board.bArea.isInThisArea(toX,toY)) return false;
+
+    if (this.team == 0 && toX-this.x==1 && toY-this.y==0) return true;
+    else if (this.team == 1 && this.x-toX==1 && toY-this.y==0) return true;
+
+    return false;
+  }
+
 }


### PR DESCRIPTION
Hiyokoクラスに，指定したマスにそのHiyokoが移動可能であるかをtrue/falseで返すcanMove()メソッドを追加した